### PR TITLE
Multiple Servers Support

### DIFF
--- a/classes/Service/SshService.ts
+++ b/classes/Service/SshService.ts
@@ -1,71 +1,78 @@
 /// <reference path="../../definitions/node/node.d.ts" />
 /// <reference path="../../definitions/Q/Q.d.ts" />
 /// <reference path="../../definitions/sprintf/sprintf.d.ts" />
-var __extends = this.__extends || function (d, b) {
-        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
-        function __() { this.constructor = d; }
-        __.prototype = b.prototype;
-        d.prototype = new __();
-    };
-var Q = require('q');
-var AbstractService = require('./AbstractService');
-var VendorSshClient = require('node-sshclient');
-var color = require('cli-color');
-var sprintf = require('sprintf-js').sprintf;
-var SshService = (function (_super) {
-    __extends(SshService, _super);
-    function SshService() {
-        _super.apply(this, arguments);
-        this.sshClients = [];
-        this.scpClients = [];
-    }
-    SshService.prototype.exec = function (command) {
-        var deferred = Q.defer(), clients = this.getSshClient(), that = this;
+
+import Q = require('q');
+import Shell = require('shelljs');
+import async = require('async');
+
+import AbstractService = require('./AbstractService');
+import SshResult = require('./SshResult');
+
+var VendorSshClient: any = require('node-sshclient');
+var color: any = require('cli-color');
+var sprintf: sPrintF.sprintf = require('sprintf-js').sprintf;
+
+class SshService extends AbstractService {
+
+    private sshClients: any = [];
+    private scpClients: any = [];
+
+    exec(command: string): Q.Promise<SshResult> {
+        var deferred = Q.defer<SshResult>(),
+            clients = this.getSshClient();
+
+
         this.services.log.logCommand('SSH cmd: ' + command);
-        clients.forEach(function(client){
-            client.command(command, function (procResult) {
-                that.services.log.logCommand('SSH Server: ' + client.options.hostname);
+
+        for(var i=0, len=clients.length; i< len; i++){
+            var client = clients[i];
+            this.services.log.logCommand('Executong cmd on SSH Server: ' + client.options.hostname);
+            client.command(command, (procResult: SshResult) => {
                 var resultString = sprintf('Response (code %s): "%s", err: "%s"', procResult.exitCode, procResult.stdout, procResult.stderr);
                 if (procResult.exitCode !== 0) {
                     deferred.reject(resultString);
-                }
-                else {
+                } else {
                     //this.services.log.logResult(resultString);
                     deferred.resolve(procResult);
                 }
             });
-        });
+        }
 
         return deferred.promise;
-    };
-    SshService.prototype.upload = function (filename, remoteFilename) {
-        var _this = this;
-        var deferred = Q.defer();
+    }
 
-        this.getScpClient().forEach(function(scpClient){
-            _this.services.log.startSection(sprintf('Uploading "%s" to "%s"', filename, remoteFilename));
-            scpClient.upload(filename, remoteFilename, function (procResult) {
+    upload(filename: string, remoteFilename: string) {
+        var deferred = Q.defer(), scpClients = this.getScpClient();
+
+        for(var i=0, len=scpClients.length; i< len; i++){
+            var scpClient = scpClients[i];
+            this.services.log.startSection(sprintf('Uploading "%s" to "%s"', filename, remoteFilename));
+            scpClient.upload(filename, remoteFilename, (procResult: any) => {
                 if (procResult.exitCode !== 0) {
                     deferred.reject(procResult.stderr);
                     return;
                 }
-                _this.services.log.closeSection('Upload complete');
+                this.services.log.closeSection('Upload complete');
                 deferred.resolve(procResult);
             });
-        })
+        }
         return deferred.promise;
-    };
-    SshService.prototype.getSshClient = function () {
-        var server, hosts = [], that = this;
+    }
+
+    private getSshClient(): any {
+        var server, hosts = [];
         if (this.sshClients.length < 1) {
             server = this.services.config.getStageConfig().server;
             if (!(server.host instanceof Array)) {
+                hosts = [];
                 hosts.push(server.host);
             } else {
                 hosts = server.host;
             }
 
-            hosts.forEach(function(host){
+            for(var i=0, len=hosts.length; i< len; i++){
+                var host = hosts[i];
                 var port = host.match('(?:\:)[^\:]*$');
                 host = (''+host).replace(port,'');
                 port = port == null ? server.port : (''+port).replace(':','');
@@ -74,22 +81,23 @@ var SshService = (function (_super) {
                 host = host.replace(user,'');
                 host = host.replace('@','');
                 user = user == null ? server.user : (''+user).replace('@','');
+                this.services.log.logCommand(sprintf('Connecting SSH to %s@%s:%s ...', user, host, port));
 
-                that.services.log.logCommand(sprintf('Connecting SSH to %s@%s:%s ...', user, host, port));
-
-                that.sshClients.push(new VendorSshClient.SSH({
+                this.sshClients.push(new VendorSshClient.SSH({
                         hostname: host,
                         user: user,
                         port: port
                     })
                 );
-            });
+            }
 
         }
         return this.sshClients;
-    };
-    SshService.prototype.getScpClient = function () {
-        var server, hosts = [], that = this;
+    }
+
+    private getScpClient(): any {
+        var server, hosts = [];
+
         if (this.scpClients.length < 1) {
             server = this.services.config.getStageConfig().server;
             if (!(server.host instanceof Array)) {
@@ -98,8 +106,8 @@ var SshService = (function (_super) {
                 hosts = server.host;
             }
 
-            hosts.forEach(function(host){
-
+            for(var i=0, len=hosts.length; i< len; i++){
+                var host = hosts[i];
                 var port = host.match('(?:\:)[^\:]*$');
                 host = (''+host).replace(port,'');
                 port = port == null ? server.port : (''+port).replace(':','');
@@ -109,18 +117,18 @@ var SshService = (function (_super) {
                 host = host.replace('@','');
                 user = user == null ? server.user : (''+user).replace('@','');
 
-                that.services.log.logCommand(sprintf('Connecting SCP to %s@%s:%s ...', user, host, port));
+                this.services.log.logCommand(sprintf('Connecting SCP to %s@%s:%s ...', user, host, port));
 
-                that.scpClients.push(new VendorSshClient.SCP({
+                this.scpClients.push(new VendorSshClient.SCP({
                         hostname: host,
                         user: user,
                         port: port
                     })
                 );
-            });
+            }
         }
         return this.scpClients;
-    };
-    return SshService;
-})(AbstractService);
-module.exports = SshService;
+    }
+}
+
+export = SshService;

--- a/classes/Service/SshService.ts
+++ b/classes/Service/SshService.ts
@@ -1,86 +1,103 @@
 /// <reference path="../../definitions/node/node.d.ts" />
 /// <reference path="../../definitions/Q/Q.d.ts" />
 /// <reference path="../../definitions/sprintf/sprintf.d.ts" />
-
-import Q = require('q');
-import Shell = require('shelljs');
-import async = require('async');
-
-import AbstractService = require('./AbstractService');
-import SshResult = require('./SshResult');
-
-var VendorSshClient: any = require('node-sshclient');
-var color: any = require('cli-color');
-var sprintf: sPrintF.sprintf = require('sprintf-js').sprintf;
-
-class SshService extends AbstractService {
-
-    private sshClient: any = null;
-    private scpClient: any = null;
-
-    exec(command: string): Q.Promise<SshResult> {
-        var deferred = Q.defer<SshResult>(),
-            client = this.getSshClient();
-
+var __extends = this.__extends || function (d, b) {
+        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        function __() { this.constructor = d; }
+        __.prototype = b.prototype;
+        d.prototype = new __();
+    };
+var Q = require('q');
+var AbstractService = require('./AbstractService');
+var VendorSshClient = require('node-sshclient');
+var color = require('cli-color');
+var sprintf = require('sprintf-js').sprintf;
+var SshService = (function (_super) {
+    __extends(SshService, _super);
+    function SshService() {
+        _super.apply(this, arguments);
+        this.sshClients = [];
+        this.scpClients = [];
+    }
+    SshService.prototype.exec = function (command) {
+        var deferred = Q.defer(), clients = this.getSshClient(), that = this;
         this.services.log.logCommand('SSH cmd: ' + command);
-
-        client.command(command, (procResult: SshResult) => {
-            var resultString = sprintf('Response (code %s): "%s", err: "%s"', procResult.exitCode, procResult.stdout, procResult.stderr);
-            if (procResult.exitCode !== 0) {
-                deferred.reject(resultString);
-            } else {
-                //this.services.log.logResult(resultString);
-                deferred.resolve(procResult);
-            }
+        clients.forEach(function(client){
+            client.command(command, function (procResult) {
+                that.services.log.logCommand('SSH Server: ' + client.hostname);
+                var resultString = sprintf('Response (code %s): "%s", err: "%s"', procResult.exitCode, procResult.stdout, procResult.stderr);
+                if (procResult.exitCode !== 0) {
+                    deferred.reject(resultString);
+                }
+                else {
+                    //this.services.log.logResult(resultString);
+                    deferred.resolve(procResult);
+                }
+            });
         });
 
         return deferred.promise;
-    }
-
-    upload(filename: string, remoteFilename: string) {
+    };
+    SshService.prototype.upload = function (filename, remoteFilename) {
+        var _this = this;
         var deferred = Q.defer();
-
         this.services.log.startSection(sprintf('Uploading "%s" to "%s"', filename, remoteFilename));
-        this.getScpClient().upload(filename, remoteFilename, (procResult: any) => {
-            if (procResult.exitCode !== 0) {
-                deferred.reject(procResult.stderr);
-                return;
-            }
-            this.services.log.closeSection('Upload complete');
-            deferred.resolve(procResult);
-        });
+        this.getScpClient().forEach(function(scpClient){
+            scpClient.upload(filename, remoteFilename, function (procResult) {
+                if (procResult.exitCode !== 0) {
+                    deferred.reject(procResult.stderr);
+                    return;
+                }
+                _this.services.log.closeSection('Upload complete');
+                deferred.resolve(procResult);
+            });
+        })
         return deferred.promise;
-    }
-
-    private getSshClient(): any {
-        var server;
-
-        if (this.sshClient === null) {
+    };
+    SshService.prototype.getSshClient = function () {
+        var server, hosts = [], that = this;
+        if (this.sshClients.length < 1) {
             server = this.services.config.getStageConfig().server;
-            this.services.log.logCommand(sprintf('Connecting SSH to %s@%s:%s ...', server.user, server.host, server.port));
-            this.sshClient = new VendorSshClient.SSH({
-                hostname: server.host,
-                user:     server.user,
-                port:     server.port
+            if (!(server.host instanceof Array)) {
+                hosts.push(server.host);
+            } else {
+                hosts = server.host;
+            }
+            this.services.log.logCommand(sprintf('Connecting SSH to %s@%s:%s ...', server.user, hosts, server.port));
+            hosts.forEach(function(host){
+                that.sshClients.push(new VendorSshClient.SSH({
+                        hostname: host,
+                        user: server.user,
+                        port: server.port
+                    })
+                );
+            });
+
+        }
+        return this.sshClients;
+    };
+    SshService.prototype.getScpClient = function () {
+        var server, hosts = [], that = this;
+        if (this.scpClients.length < 1) {
+            server = this.services.config.getStageConfig().server;
+            if (!(server.host instanceof Array)) {
+                hosts.push(server.host);
+            } else {
+                hosts = server.host;
+            }
+
+            this.services.log.logCommand(sprintf('Connecting SCP to %s@%s:%s ...', server.user, server.host, server.port));
+            hosts.forEach(function(host){
+                that.scpClients.push(new VendorSshClient.SCP({
+                        hostname: host,
+                        user: server.user,
+                        port: server.port
+                    })
+                );
             });
         }
-        return this.sshClient;
-    }
-
-    private getScpClient(): any {
-        var server;
-
-        if (this.scpClient === null) {
-            server = this.services.config.getStageConfig().server;
-            this.services.log.logCommand(sprintf('Connecting SCP to %s@%s:%s ...', server.user, server.host, server.port));
-            this.scpClient = new VendorSshClient.SCP({
-                hostname: server.host,
-                user:     server.user,
-                port:     server.port
-            })
-        }
-        return this.scpClient;
-    }
-}
-
-export = SshService;
+        return this.scpClients;
+    };
+    return SshService;
+})(AbstractService);
+module.exports = SshService;

--- a/classes/Service/SshService.ts
+++ b/classes/Service/SshService.ts
@@ -1,86 +1,103 @@
 /// <reference path="../../definitions/node/node.d.ts" />
 /// <reference path="../../definitions/Q/Q.d.ts" />
 /// <reference path="../../definitions/sprintf/sprintf.d.ts" />
-
-import Q = require('q');
-import Shell = require('shelljs');
-import async = require('async');
-
-import AbstractService = require('./AbstractService');
-import SshResult = require('./SshResult');
-
-var VendorSshClient: any = require('node-sshclient');
-var color: any = require('cli-color');
-var sprintf: sPrintF.sprintf = require('sprintf-js').sprintf;
-
-class SshService extends AbstractService {
-
-    private sshClient: any = null;
-    private scpClient: any = null;
-
-    exec(command: string): Q.Promise<SshResult> {
-        var deferred = Q.defer<SshResult>(),
-            client = this.getSshClient();
-
+var __extends = this.__extends || function (d, b) {
+        for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        function __() { this.constructor = d; }
+        __.prototype = b.prototype;
+        d.prototype = new __();
+    };
+var Q = require('q');
+var AbstractService = require('./AbstractService');
+var VendorSshClient = require('node-sshclient');
+var color = require('cli-color');
+var sprintf = require('sprintf-js').sprintf;
+var SshService = (function (_super) {
+    __extends(SshService, _super);
+    function SshService() {
+        _super.apply(this, arguments);
+        this.sshClients = [];
+        this.scpClients = [];
+    }
+    SshService.prototype.exec = function (command) {
+        var deferred = Q.defer(), clients = this.getSshClient(), that = this;
         this.services.log.logCommand('SSH cmd: ' + command);
-
-        client.command(command, (procResult: SshResult) => {
-            var resultString = sprintf('Response (code %s): "%s", err: "%s"', procResult.exitCode, procResult.stdout, procResult.stderr);
-            if (procResult.exitCode !== 0) {
-                deferred.reject(resultString);
-            } else {
-                //this.services.log.logResult(resultString);
-                deferred.resolve(procResult);
-            }
+        clients.forEach(function(client){
+            client.command(command, function (procResult) {
+                that.services.log.logCommand('SSH Server: ' + client.options.hostname);
+                var resultString = sprintf('Response (code %s): "%s", err: "%s"', procResult.exitCode, procResult.stdout, procResult.stderr);
+                if (procResult.exitCode !== 0) {
+                    deferred.reject(resultString);
+                }
+                else {
+                    //this.services.log.logResult(resultString);
+                    deferred.resolve(procResult);
+                }
+            });
         });
 
         return deferred.promise;
-    }
-
-    upload(filename: string, remoteFilename: string) {
+    };
+    SshService.prototype.upload = function (filename, remoteFilename) {
+        var _this = this;
         var deferred = Q.defer();
-
         this.services.log.startSection(sprintf('Uploading "%s" to "%s"', filename, remoteFilename));
-        this.getScpClient().upload(filename, remoteFilename, (procResult: any) => {
-            if (procResult.exitCode !== 0) {
-                deferred.reject(procResult.stderr);
-                return;
-            }
-            this.services.log.closeSection('Upload complete');
-            deferred.resolve(procResult);
-        });
+        this.getScpClient().forEach(function(scpClient){
+            scpClient.upload(filename, remoteFilename, function (procResult) {
+                if (procResult.exitCode !== 0) {
+                    deferred.reject(procResult.stderr);
+                    return;
+                }
+                _this.services.log.closeSection('Upload complete');
+                deferred.resolve(procResult);
+            });
+        })
         return deferred.promise;
-    }
-
-    private getSshClient(): any {
-        var server;
-
-        if (this.sshClient === null) {
+    };
+    SshService.prototype.getSshClient = function () {
+        var server, hosts = [], that = this;
+        if (this.sshClients.length < 1) {
             server = this.services.config.getStageConfig().server;
-            this.services.log.logCommand(sprintf('Connecting SSH to %s@%s:%s ...', server.user, server.host, server.port));
-            this.sshClient = new VendorSshClient.SSH({
-                hostname: server.host,
-                user:     server.user,
-                port:     server.port
+            if (!(server.host instanceof Array)) {
+                hosts.push(server.host);
+            } else {
+                hosts = server.host;
+            }
+            this.services.log.logCommand(sprintf('Connecting SSH to %s@%s:%s ...', server.user, hosts, server.port));
+            hosts.forEach(function(host){
+                that.sshClients.push(new VendorSshClient.SSH({
+                        hostname: host,
+                        user: server.user,
+                        port: server.port
+                    })
+                );
+            });
+
+        }
+        return this.sshClients;
+    };
+    SshService.prototype.getScpClient = function () {
+        var server, hosts = [], that = this;
+        if (this.scpClients.length < 1) {
+            server = this.services.config.getStageConfig().server;
+            if (!(server.host instanceof Array)) {
+                hosts.push(server.host);
+            } else {
+                hosts = server.host;
+            }
+
+            this.services.log.logCommand(sprintf('Connecting SCP to %s@%s:%s ...', server.user, server.host, server.port));
+            hosts.forEach(function(host){
+                that.scpClients.push(new VendorSshClient.SCP({
+                        hostname: host,
+                        user: server.user,
+                        port: server.port
+                    })
+                );
             });
         }
-        return this.sshClient;
-    }
-
-    private getScpClient(): any {
-        var server;
-
-        if (this.scpClient === null) {
-            server = this.services.config.getStageConfig().server;
-            this.services.log.logCommand(sprintf('Connecting SCP to %s@%s:%s ...', server.user, server.host, server.port));
-            this.scpClient = new VendorSshClient.SCP({
-                hostname: server.host,
-                user:     server.user,
-                port:     server.port
-            })
-        }
-        return this.scpClient;
-    }
-}
-
-export = SshService;
+        return this.scpClients;
+    };
+    return SshService;
+})(AbstractService);
+module.exports = SshService;


### PR DESCRIPTION
Added multiple servers deployment with fallback for the old settings, usage:
host: server.com
or
host: [user@server1.com:port, user@server2.com, server3.com:port]

Default is user and port defined in the settings
